### PR TITLE
Disable subscribing when consumer is undefined

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jucr/nestjs-kafka-events",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Lightweight, tested, straight-forward wrapper around KafkaJS and Confluent's Schema Registry.",
   "author": "Max Gr. <grollmann@jucr.de>",
   "private": false,

--- a/src/kafka.service.ts
+++ b/src/kafka.service.ts
@@ -164,6 +164,9 @@ export class KafkaService
    * @private
    */
   private async subscribeToTopics(): Promise<void> {
+    if (!this.consumer) {
+      return;
+    }
     for await (const topic of this.kafkaEventFunctionsService.getEventHandlerTopics()) {
       try {
         await this.consumer.subscribe({ topic, fromBeginning: false });


### PR DESCRIPTION
Disables subscribing to topics when configuration for the consumer of `KafkaJS` is not set. Prevents errors like "Cannot read property 'subscribe' of undefined".